### PR TITLE
fix: prevent corruption of native Claude Code binary on macOS

### DIFF
--- a/lib/parallel-execution.js
+++ b/lib/parallel-execution.js
@@ -19,18 +19,38 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 /**
+ * Check if file is a native binary (Mach-O, ELF, etc.) vs JavaScript
+ * @param {string} filePath - Path to file
+ * @returns {boolean} true if native binary
+ */
+function isNativeBinary(filePath) {
+  try {
+    const magic = Buffer.alloc(4);
+    const fd = fs.openSync(filePath, 'r');
+    fs.readSync(fd, magic, 0, 4, 0);
+    fs.closeSync(fd);
+    const hex = magic.toString('hex');
+    return hex === 'cffaedfe' || hex === 'cafebabe' || hex === '7f454c46';
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Detect if TeammateTool is available in current Claude Code installation
  * Auto-enables if possible
  */
 export function detectTeammateTool() {
   try {
-    // Find Claude Code installation
     const claudePath = findClaudeCodeBinary();
     if (!claudePath) {
       return { available: false, reason: 'Claude Code binary not found' };
     }
 
-    // Read CLI content
+    if (isNativeBinary(claudePath)) {
+      return { available: false, reason: 'Native binary detected - patching not supported', isNative: true };
+    }
+
     const cliContent = fs.readFileSync(claudePath, 'utf8');
 
     // Check for TeammateTool presence
@@ -128,6 +148,10 @@ export function enableTeammateTool() {
     const claudePath = findClaudeCodeBinary();
     if (!claudePath) {
       throw new Error('Claude Code binary not found');
+    }
+
+    if (isNativeBinary(claudePath)) {
+      return { success: false, error: 'Native binary detected - patching not supported. TeammateTool patching only works with npm-installed Claude Code.' };
     }
 
     // Backup original


### PR DESCRIPTION
## Problem

The `parallel-execution.js` module corrupts native Claude Code binaries on macOS when running `npx @itz4blitz/agentful init`.

The code reads the Claude Code binary as UTF-8 text (`fs.readFileSync(claudePath, 'utf8')`), which replaces invalid byte sequences with U+FFFD replacement characters (`ef bf bd`). When written back, the binary becomes corrupted and fails with `exec format error`.

This affects users who install Claude Code via the official bash installer (`curl -fsSL https://claude.ai/install.sh | bash`), which produces a native Mach-O binary rather than the npm-installed JavaScript version.

## Solution

Added `isNativeBinary()` helper that checks file magic bytes before any read operations:
- `cffaedfe` - Mach-O 64-bit (macOS arm64/x64)
- `cafebabe` - Mach-O universal binary
- `7f454c46` - ELF (Linux)

Both `detectTeammateTool()` and `enableTeammateTool()` now check for native binaries and skip patching with an appropriate message.

## Testing

- Added 2 new tests for native binary detection and rejection
- All 636 tests pass

## Reproduction

```bash
# Install native Claude Code
curl -fsSL https://claude.ai/install.sh | bash

# Run agentful init (corrupts binary)
npx @itz4blitz/agentful init

# Binary is now corrupted
claude --version
# zsh: exec format error: claude
```