### PR TITLE
fix: correct hook paths from .claude/hooks to bin/hooks

### DIFF
--- a/lib/presets.js
+++ b/lib/presets.js
@@ -103,7 +103,7 @@ export const hookConfigurations = {
     event: 'SessionStart',
     config: {
       type: 'command',
-      command: 'node .claude/hooks/session-start.js',
+      command: 'node bin/hooks/session-start.js',
       timeout: 3,
       description: 'Intelligent context awareness - shows project status and suggests next steps'
     }
@@ -114,7 +114,7 @@ export const hookConfigurations = {
     matcher: 'SlashCommand',
     config: {
       type: 'command',
-      command: 'node .claude/hooks/post-action-suggestions.js',
+      command: 'node bin/hooks/post-action-suggestions.js',
       timeout: 3,
       description: 'Smart suggestions for what to do next after slash commands'
     }


### PR DESCRIPTION
## Problem

The `session-start` and `post-action-suggestions` hooks in `lib/presets.js` are configured with incorrect paths (`.claude/hooks/`) while all other hooks correctly use `bin/hooks/`.

This causes `MODULE_NOT_FOUND` errors on SessionStart:

```
SessionStart:startup hook error: Failed with non-blocking status code: 
Error: Cannot find module '/path/to/project/.claude/hooks/session-start.js'
    code: 'MODULE_NOT_FOUND'
```

## Root Cause

In `lib/presets.js`, two hooks had inconsistent paths:

```javascript
// Before (incorrect)
command: 'node .claude/hooks/session-start.js'
command: 'node .claude/hooks/post-action-suggestions.js'

// After (correct - matches all other hooks)
command: 'node bin/hooks/session-start.js'
command: 'node bin/hooks/post-action-suggestions.js'
```

## Fix

Updated both hook paths to use `bin/hooks/` which is where `initProject()` actually installs them.

## Testing

All 636 tests pass.